### PR TITLE
Postinstall step to build dist-es5 and dist-es6 

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:example": "webpack -p --config-name example",
     "build:es5": "buble lib --objectAssign -o dist-es5",
     "build:es6": "buble lib --objectAssign -o dist-es6 -t node:6",
-    "prepublish": "npm run build:es5 && npm run build:es6"
+    "prepublish": "npm run build:es5 && npm run build:es6",
+    "postinstall": "npm install buble@0.17.1 && npm run build:es5 && npm run build:es6"
   },
   "files": [
     "lib",


### PR DESCRIPTION
There was a prepublish step that would do the builds before publishing to npm, but if you just pull from github the builds weren't done.

https://clypdinc.atlassian.net/browse/MAIN-30998