### PR TITLE
make buble a real dependency, not a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:es5": "buble lib --objectAssign -o dist-es5",
     "build:es6": "buble lib --objectAssign -o dist-es6 -t node:6",
     "prepublish": "npm run build:es5 && npm run build:es6",
-    "postinstall": "npm install buble@0.17.1 && npm run build:es5 && npm run build:es6"
+    "postinstall": "npm run build:es5 && npm run build:es6"
   },
   "files": [
     "lib",
@@ -46,8 +46,10 @@
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0"
   },
+  "dependencies": {
+    "buble": "^0.17.1"
+  },
   "devDependencies": {
-    "buble": "^0.17.0",
     "buble-loader": "^0.4.1",
     "coveralls": "^3.0.0",
     "istanbul": "^0.4.4",


### PR DESCRIPTION
In order to run the postinstall step, you need buble. The `npm install buble` command didn't always work, so just make `buble` a real dependency and npm will take care of it the right way.

Previously I only checked that this worked locally, now I've tested that it works locally AND works for building a sandbox.